### PR TITLE
vfs-local: Allow for both fs.watch and fs.watchFile semantics.

### DIFF
--- a/example/vfs-watch-example.js
+++ b/example/vfs-watch-example.js
@@ -8,13 +8,15 @@ var Parent = require('vfs-child').Parent;
 var parent = new Parent({root: __dirname + "/"});
 parent.connect(function (err, vfs) {
   if (err) throw err;
-  // watch(vfs);
-  changed(vfs);
+  watch(vfs);
+  // changed(vfs);
 });
 
 
 function watch(vfs) {
-  vfs.watch(".", {}, function (err, meta) {
+  // vfs.watch(".", {}, onWatch);
+  vfs.watch("vfs-watch-example.js", {file:true}, onWatch);
+  function onWatch(err, meta) {
     if (err) throw err;
     var watcher = meta.watcher;
     watcher.on("change", function (event, filename) {
@@ -24,7 +26,7 @@ function watch(vfs) {
       console.log("Closing...");
       watcher.close()
     }, 10000);
-  });
+  }
 }
 
 function changed(vfs) {

--- a/local/localfs.js
+++ b/local/localfs.js
@@ -933,7 +933,15 @@ module.exports = function setup(fsOptions) {
     var meta = {};
     realpath(path, function (err, path) {
       if (err) return callback(err);
-      meta.watcher = fs.watchFile(path, options, function (currStat, prevStat) {});
+      if (options.file) {
+        meta.watcher = fs.watchFile(path, options, function () {});
+        meta.watcher.close = function () {
+          fs.unwatchFile(path);
+        };
+      }
+      else {
+        meta.watcher = fs.watch(path, options);
+      }
       callback(null, meta);
     });
   }


### PR DESCRIPTION
Instead of adding multiple watcher APIs, let's just pass a flag {file: true} to vfs.watch that chooses between the two backends.  In both cases you will need to call .close() on the resultant emitter object as well as listen for "change" events.
